### PR TITLE
Calender api 구현 및 테스트 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out/
 
 # 로컬 설정 파일 제외
 application-local.yml
+
+.antigravityrules

--- a/src/main/java/com/guthub/guthubserver/api/GutHealthController.java
+++ b/src/main/java/com/guthub/guthubserver/api/GutHealthController.java
@@ -1,0 +1,39 @@
+package com.guthub.guthubserver.api;
+
+import com.guthub.guthubserver.domain.gut.dto.GutHealthScoreResponseDto;
+import com.guthub.guthubserver.domain.gut.dto.MonthlyGutHealthResponseDto;
+import com.guthub.guthubserver.domain.gut.service.GutHealthScoreService;
+import com.guthub.guthubserver.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users/me")
+public class GutHealthController {
+
+    private final GutHealthScoreService gutHealthScoreService;
+
+    @GetMapping("/gut-health")
+    public ResponseEntity<ApiResponse<GutHealthScoreResponseDto>> getGutHealthScore(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        GutHealthScoreResponseDto result = gutHealthScoreService.getGutHealthScore(date);
+        return ResponseEntity.ok(
+                ApiResponse.of("SUCCESS", "요청이 성공하였습니다.", result));
+    }
+
+    @GetMapping("/gut-health/monthly")
+    public ResponseEntity<ApiResponse<MonthlyGutHealthResponseDto>> getMonthlyGutHealthScore(
+            @RequestParam String month) {
+        MonthlyGutHealthResponseDto result = gutHealthScoreService.getMonthlyGutHealthScore(month);
+        return ResponseEntity.ok(
+                ApiResponse.of("SUCCESS", "요청이 성공하였습니다.", result));
+    }
+}

--- a/src/main/java/com/guthub/guthubserver/domain/diet/service/DietLogService.java
+++ b/src/main/java/com/guthub/guthubserver/domain/diet/service/DietLogService.java
@@ -53,7 +53,8 @@ public class DietLogService {
         List<DietLog> savedDietLogs = requestDto.getItems().stream()
                 .map(itemDto -> {
                     Food food = foodRepository.findByName(itemDto.getFoodName())
-                            .orElseThrow(() -> new IllegalArgumentException("Food not found: " + itemDto.getFoodName()));
+                            .orElseThrow(
+                                    () -> new IllegalArgumentException("Food not found: " + itemDto.getFoodName()));
 
                     DietLog dietLog = DietLog.builder()
                             .user(user)
@@ -87,7 +88,8 @@ public class DietLogService {
                 .collect(Collectors.groupingBy(DietLogResponseDto::getMealType));
 
         DailyDietSummaryResponseDto.TotalNutrientInfo totalNutrientInfo = calculateTotalNutrients(dietLogs);
-        DailyDietSummaryResponseDto.GutHealthAnalysis gutHealthAnalysis = analyzeGutHealth(user.getGutType(), totalNutrientInfo);
+        DailyDietSummaryResponseDto.GutHealthAnalysis gutHealthAnalysis = analyzeGutHealth(user.getGutType(),
+                totalNutrientInfo);
 
         return DailyDietSummaryResponseDto.builder()
                 .date(date)
@@ -206,21 +208,39 @@ public class DietLogService {
     public void updateDailyGutHealthScore(UserEntity user, LocalDate date) {
         List<DietLog> dietLogs = dietLogRepository.findAllByUserAndLogDate(user, date);
         DailyDietSummaryResponseDto.TotalNutrientInfo totalNutrientInfo = calculateTotalNutrients(dietLogs);
-        DailyDietSummaryResponseDto.GutHealthAnalysis gutHealthAnalysis = analyzeGutHealth(user.getGutType(), totalNutrientInfo);
+        DailyDietSummaryResponseDto.GutHealthAnalysis gutHealthAnalysis = analyzeGutHealth(user.getGutType(),
+                totalNutrientInfo);
+
+        // badCount와 violationReason 계산
+        int badCountTemp = 0;
+        List<String> violatedNutrients = new ArrayList<>();
+        for (DailyDietSummaryResponseDto.GutHealthAnalysis.NutrientComparison comparison : gutHealthAnalysis
+                .getComparisons()) {
+            if (comparison.isExceeded()) {
+                badCountTemp++;
+                violatedNutrients.add(comparison.getNutrientName() + " 초과");
+            } else if (comparison.isBelowMin()) {
+                badCountTemp++;
+                violatedNutrients.add(comparison.getNutrientName() + " 부족");
+            }
+        }
+        final int badCount = badCountTemp;
+        final String violationReason = violatedNutrients.isEmpty() ? null : String.join(", ", violatedNutrients);
 
         dailyGutHealthScoreRepository.findByUserAndRecordDate(user, date)
                 .ifPresentOrElse(
-                        score -> score.updateOverallStatus(gutHealthAnalysis.getOverallStatus()),
+                        score -> score.updateScore(gutHealthAnalysis.getOverallStatus(), badCount, violationReason),
                         () -> {
                             DailyGutHealthScore newScore = DailyGutHealthScore.builder()
                                     .user(user)
                                     .recordDate(date)
                                     .overallStatus(gutHealthAnalysis.getOverallStatus())
+                                    .badCount(badCount)
+                                    .violationReason(violationReason)
                                     .build();
                             dailyGutHealthScoreRepository.save(newScore);
                         });
     }
-
 
     private DailyDietSummaryResponseDto.TotalNutrientInfo calculateTotalNutrients(List<DietLog> dietLogs) {
         float totalCalories = 0;
@@ -255,7 +275,8 @@ public class DietLogService {
                 .build();
     }
 
-    private DailyDietSummaryResponseDto.GutHealthAnalysis analyzeGutHealth(GutType userGutType, DailyDietSummaryResponseDto.TotalNutrientInfo totalNutrientInfo) {
+    private DailyDietSummaryResponseDto.GutHealthAnalysis analyzeGutHealth(GutType userGutType,
+            DailyDietSummaryResponseDto.TotalNutrientInfo totalNutrientInfo) {
         List<GutNutrientStandard> standards = gutNutrientStandardRepository.findByGutType(userGutType);
         List<DailyDietSummaryResponseDto.GutHealthAnalysis.NutrientComparison> comparisons = new ArrayList<>();
         int exceededCount = 0;

--- a/src/main/java/com/guthub/guthubserver/domain/gut/dto/GutHealthScoreResponseDto.java
+++ b/src/main/java/com/guthub/guthubserver/domain/gut/dto/GutHealthScoreResponseDto.java
@@ -1,0 +1,18 @@
+package com.guthub.guthubserver.domain.gut.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GutHealthScoreResponseDto {
+
+    private String status; // "GOOD", "NORMAL", "BAD"
+    private Integer badCount; // nullable
+    private String violationReason; // nullable
+    private LocalDateTime updatedAt; // nullable
+}

--- a/src/main/java/com/guthub/guthubserver/domain/gut/dto/MonthlyGutHealthResponseDto.java
+++ b/src/main/java/com/guthub/guthubserver/domain/gut/dto/MonthlyGutHealthResponseDto.java
@@ -1,0 +1,26 @@
+package com.guthub.guthubserver.domain.gut.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class MonthlyGutHealthResponseDto {
+
+    private List<DailyStatus> statusList;
+
+    @Getter
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class DailyStatus {
+        private String date; // "2025-12-01"
+        private String status; // "GOOD", "NORMAL", "BAD"
+        private Integer badCount; // nullable
+        private String violationReason; // nullable
+        private LocalDateTime updatedAt; // nullable
+    }
+}

--- a/src/main/java/com/guthub/guthubserver/domain/gut/entity/DailyGutHealthScore.java
+++ b/src/main/java/com/guthub/guthubserver/domain/gut/entity/DailyGutHealthScore.java
@@ -21,10 +21,7 @@ import java.time.LocalDate;
 
 @Entity
 @Table(name = "daily_gut_health_scores", uniqueConstraints = { // uniqueConstraints 추가
-    @UniqueConstraint(
-        name = "uk_user_record_date",
-        columnNames = {"user_id", "record_date"}
-    )
+        @UniqueConstraint(name = "uk_user_record_date", columnNames = { "user_id", "record_date" })
 })
 @Getter
 @Builder
@@ -43,7 +40,23 @@ public class DailyGutHealthScore extends BaseEntity {
     @Column(name = "overall_status", nullable = false, length = 20)
     private OverallGutHealthStatus overallStatus;
 
+    @Column(name = "bad_count")
+    private Integer badCount;
+
+    @Column(name = "violation_reason")
+    private String violationReason;
+
+    @org.hibernate.annotations.UpdateTimestamp
+    @Column(name = "updated_at")
+    private java.time.LocalDateTime updatedAt;
+
     public void updateOverallStatus(OverallGutHealthStatus overallStatus) {
         this.overallStatus = overallStatus;
+    }
+
+    public void updateScore(OverallGutHealthStatus overallStatus, Integer badCount, String violationReason) {
+        this.overallStatus = overallStatus;
+        this.badCount = badCount;
+        this.violationReason = violationReason;
     }
 }

--- a/src/main/java/com/guthub/guthubserver/domain/gut/repository/DailyGutHealthScoreRepository.java
+++ b/src/main/java/com/guthub/guthubserver/domain/gut/repository/DailyGutHealthScoreRepository.java
@@ -14,26 +14,31 @@ import java.util.Optional;
 public interface DailyGutHealthScoreRepository extends JpaRepository<DailyGutHealthScore, Long> {
     Optional<DailyGutHealthScore> findByUserAndRecordDate(UserEntity user, LocalDate recordDate);
 
+    Optional<DailyGutHealthScore> findByUser_IdAndRecordDate(Long userId, LocalDate recordDate);
+
+    List<DailyGutHealthScore> findByUser_IdAndRecordDateBetweenOrderByRecordDateAsc(
+            Long userId, LocalDate startDate, LocalDate endDate);
+
     List<DailyGutHealthScore> findByUserOrderByRecordDateDesc(UserEntity user);
 
     @Query(value = """
-        SELECT
-            COUNT(dghs.id) AS streakCount,
-            MAX(dghs.record_date) AS lastRecordDate
-        FROM
-            daily_gut_health_scores dghs
-        WHERE
-            dghs.user_id = :userId
-            AND dghs.overall_status = 'GOOD'
-            AND dghs.record_date <= CURRENT_DATE()
-            AND dghs.record_date > COALESCE(
-                (SELECT MAX(dghs2.record_date)
-                 FROM daily_gut_health_scores dghs2
-                 WHERE dghs2.user_id = :userId
-                   AND dghs2.overall_status != 'GOOD'
-                   AND dghs2.record_date < CURRENT_DATE()),
-                DATE '1900-01-01'
-            )
-        """, nativeQuery = true)
+            SELECT
+                COUNT(dghs.id) AS streakCount,
+                MAX(dghs.record_date) AS lastRecordDate
+            FROM
+                daily_gut_health_scores dghs
+            WHERE
+                dghs.user_id = :userId
+                AND dghs.overall_status = 'GOOD'
+                AND dghs.record_date <= CURRENT_DATE()
+                AND dghs.record_date > COALESCE(
+                    (SELECT MAX(dghs2.record_date)
+                     FROM daily_gut_health_scores dghs2
+                     WHERE dghs2.user_id = :userId
+                       AND dghs2.overall_status != 'GOOD'
+                       AND dghs2.record_date < CURRENT_DATE()),
+                    DATE '1900-01-01'
+                )
+            """, nativeQuery = true)
     Map<String, Object> getGutHealthStreakNative(@Param("userId") Long userId);
 }

--- a/src/main/java/com/guthub/guthubserver/domain/gut/service/GutHealthScoreService.java
+++ b/src/main/java/com/guthub/guthubserver/domain/gut/service/GutHealthScoreService.java
@@ -1,0 +1,98 @@
+package com.guthub.guthubserver.domain.gut.service;
+
+import com.guthub.guthubserver.domain.gut.dto.GutHealthScoreResponseDto;
+import com.guthub.guthubserver.domain.gut.dto.MonthlyGutHealthResponseDto;
+import com.guthub.guthubserver.domain.gut.entity.DailyGutHealthScore;
+import com.guthub.guthubserver.domain.gut.repository.DailyGutHealthScoreRepository;
+import com.guthub.guthubserver.domain.user.entity.UserEntity;
+import com.guthub.guthubserver.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GutHealthScoreService {
+
+    private final DailyGutHealthScoreRepository dailyGutHealthScoreRepository;
+    private final UserRepository userRepository;
+
+    public GutHealthScoreResponseDto getGutHealthScore(LocalDate date) {
+        // 인증된 사용자 정보 추출
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        UserEntity user = userRepository.findByUsernameAndIsLock(username, false)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        // 미래 날짜 검증
+        if (date.isAfter(LocalDate.now())) {
+            throw new IllegalArgumentException("미래의 날짜는 조회할 수 없습니다.");
+        }
+
+        // 데이터 조회
+        DailyGutHealthScore score = dailyGutHealthScoreRepository
+                .findByUser_IdAndRecordDate(user.getId(), date)
+                .orElseThrow(() -> new NoSuchElementException("해당 날짜의 데이터가 없습니다."));
+
+        // DTO 변환 및 반환
+        return GutHealthScoreResponseDto.builder()
+                .status(score.getOverallStatus().name())
+                .badCount(score.getBadCount())
+                .violationReason(score.getViolationReason())
+                .updatedAt(score.getUpdatedAt())
+                .build();
+    }
+
+    public MonthlyGutHealthResponseDto getMonthlyGutHealthScore(String month) {
+        // 인증된 사용자 정보 추출
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        UserEntity user = userRepository.findByUsernameAndIsLock(username, false)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        // month 파라미터 파싱 (yyyy-MM 형식)
+        YearMonth yearMonth;
+        try {
+            yearMonth = YearMonth.parse(month, DateTimeFormatter.ofPattern("yyyy-MM"));
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("날짜 또는 달을 입력하지 않았습니다.");
+        }
+
+        // 미래 달 검증
+        if (yearMonth.isAfter(YearMonth.now())) {
+            throw new IllegalArgumentException("달이 유효하지 않습니다.");
+        }
+
+        // 해당 월의 시작일과 종료일 계산
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        // 데이터 조회
+        List<DailyGutHealthScore> scores = dailyGutHealthScoreRepository
+                .findByUser_IdAndRecordDateBetweenOrderByRecordDateAsc(user.getId(), startDate, endDate);
+
+        // DTO 변환
+        List<MonthlyGutHealthResponseDto.DailyStatus> statusList = scores.stream()
+                .map(score -> MonthlyGutHealthResponseDto.DailyStatus.builder()
+                        .date(score.getRecordDate().toString())
+                        .status(score.getOverallStatus().name())
+                        .badCount(score.getBadCount())
+                        .violationReason(score.getViolationReason())
+                        .updatedAt(score.getUpdatedAt())
+                        .build())
+                .collect(Collectors.toList());
+
+        return MonthlyGutHealthResponseDto.builder()
+                .statusList(statusList)
+                .build();
+    }
+}

--- a/src/main/resources/data-dev.sql
+++ b/src/main/resources/data-dev.sql
@@ -85,18 +85,18 @@ INSERT INTO gut_nutrient_standards (id, gut_type_id, nutrient_name, min_limit, m
 
 -- DailyGutHealthScore 테스트 데이터
 -- testuser1 (id 101)
-INSERT INTO daily_gut_health_scores (id, user_id, record_date, overall_status) VALUES
-(501, 101, CURRENT_DATE(), 'GOOD'),
-(502, 101, CURRENT_DATE() - 1, 'GOOD'),
-(503, 101, CURRENT_DATE() - 2, 'BAD'),
-(504, 101, CURRENT_DATE() - 3, 'NORMAL'),
-(505, 101, CURRENT_DATE() - 4, 'GOOD'),
-(506, 101, CURRENT_DATE() - 5, 'GOOD'),
-(507, 101, CURRENT_DATE() - 6, 'NORMAL');
+INSERT INTO daily_gut_health_scores (id, user_id, record_date, overall_status, bad_count, violation_reason, updated_at) VALUES
+(501, 101, CURRENT_DATE(), 'GOOD', 0, NULL, CURRENT_TIMESTAMP()),
+(502, 101, CURRENT_DATE() - 1, 'GOOD', 0, NULL, CURRENT_TIMESTAMP()),
+(503, 101, CURRENT_DATE() - 2, 'BAD', 5, '포화지방, 정제탄수화물, 설탕, 밀가루, 식이섬유 기준 초과', CURRENT_TIMESTAMP()),
+(504, 101, CURRENT_DATE() - 3, 'NORMAL', 2, '식이섬유 부족, 설탕 초과', CURRENT_TIMESTAMP()),
+(505, 101, CURRENT_DATE() - 4, 'GOOD', 0, NULL, CURRENT_TIMESTAMP()),
+(506, 101, CURRENT_DATE() - 5, 'GOOD', 0, NULL, CURRENT_TIMESTAMP()),
+(507, 101, CURRENT_DATE() - 6, 'NORMAL', 1, '프로바이오틱스 부족', CURRENT_TIMESTAMP());
 
 -- testuser2 (id 102)
-INSERT INTO daily_gut_health_scores (id, user_id, record_date, overall_status) VALUES
-(508, 102, CURRENT_DATE(), 'GOOD'),
-(509, 102, CURRENT_DATE() - 1, 'BAD'),
-(510, 102, CURRENT_DATE() - 2, 'NORMAL'),
-(511, 102, CURRENT_DATE() - 3, 'GOOD');
+INSERT INTO daily_gut_health_scores (id, user_id, record_date, overall_status, bad_count, violation_reason, updated_at) VALUES
+(508, 102, CURRENT_DATE(), 'GOOD', 0, NULL, CURRENT_TIMESTAMP()),
+(509, 102, CURRENT_DATE() - 1, 'BAD', 4, '포화지방, 정제탄수화물, 밀가루, 식이섬유 기준 초과', CURRENT_TIMESTAMP()),
+(510, 102, CURRENT_DATE() - 2, 'NORMAL', 1, '설탕 초과', CURRENT_TIMESTAMP()),
+(511, 102, CURRENT_DATE() - 3, 'GOOD', 0, NULL, CURRENT_TIMESTAMP());

--- a/src/main/resources/data-local.sql
+++ b/src/main/resources/data-local.sql
@@ -85,18 +85,18 @@ INSERT INTO gut_nutrient_standards (id, gut_type_id, nutrient_name, min_limit, m
 
 -- DailyGutHealthScore 테스트 데이터
 -- testuser1 (id 101)
-INSERT INTO daily_gut_health_scores (id, user_id, record_date, overall_status) VALUES
-(501, 101, CURRENT_DATE(), 'GOOD'),
-(502, 101, CURRENT_DATE() - 1, 'GOOD'),
-(503, 101, CURRENT_DATE() - 2, 'BAD'),
-(504, 101, CURRENT_DATE() - 3, 'NORMAL'),
-(505, 101, CURRENT_DATE() - 4, 'GOOD'),
-(506, 101, CURRENT_DATE() - 5, 'GOOD'),
-(507, 101, CURRENT_DATE() - 6, 'NORMAL');
+INSERT INTO daily_gut_health_scores (id, user_id, record_date, overall_status, bad_count, violation_reason, updated_at) VALUES
+(501, 101, CURRENT_DATE(), 'GOOD', 0, NULL, CURRENT_TIMESTAMP()),
+(502, 101, CURRENT_DATE() - 1, 'GOOD', 0, NULL, CURRENT_TIMESTAMP()),
+(503, 101, CURRENT_DATE() - 2, 'BAD', 5, '포화지방, 정제탄수화물, 설탕, 밀가루, 식이섬유 기준 초과', CURRENT_TIMESTAMP()),
+(504, 101, CURRENT_DATE() - 3, 'NORMAL', 2, '식이섬유 부족, 설탕 초과', CURRENT_TIMESTAMP()),
+(505, 101, CURRENT_DATE() - 4, 'GOOD', 0, NULL, CURRENT_TIMESTAMP()),
+(506, 101, CURRENT_DATE() - 5, 'GOOD', 0, NULL, CURRENT_TIMESTAMP()),
+(507, 101, CURRENT_DATE() - 6, 'NORMAL', 1, '프로바이오틱스 부족', CURRENT_TIMESTAMP());
 
 -- testuser2 (id 102)
-INSERT INTO daily_gut_health_scores (id, user_id, record_date, overall_status) VALUES
-(508, 102, CURRENT_DATE(), 'GOOD'),
-(509, 102, CURRENT_DATE() - 1, 'BAD'),
-(510, 102, CURRENT_DATE() - 2, 'NORMAL'),
-(511, 102, CURRENT_DATE() - 3, 'GOOD');
+INSERT INTO daily_gut_health_scores (id, user_id, record_date, overall_status, bad_count, violation_reason, updated_at) VALUES
+(508, 102, CURRENT_DATE(), 'GOOD', 0, NULL, CURRENT_TIMESTAMP()),
+(509, 102, CURRENT_DATE() - 1, 'BAD', 4, '포화지방, 정제탄수화물, 밀가루, 식이섬유 기준 초과', CURRENT_TIMESTAMP()),
+(510, 102, CURRENT_DATE() - 2, 'NORMAL', 1, '설탕 초과', CURRENT_TIMESTAMP()),
+(511, 102, CURRENT_DATE() - 3, 'GOOD', 0, NULL, CURRENT_TIMESTAMP());


### PR DESCRIPTION
구현된 api
GET users/me/gut-health?date=xxx
GET users/me/gut-health/monthly?month=xxx
장 건강 점수 db에 badCount, violationReason, updatedAt 필드 추가, entity, repository에 반영
테스트 데이터도 해당 필드 추가
*관련 api 명세 일부 변경
status에 green, red 대신 GOOD, BAD, NORMAL을 표시하도록 수정. 준재하지 않는 날짜는 response body에 출력되지 않음
